### PR TITLE
Correct the value of C2 to 220nF in Eagle and BOM files

### DIFF
--- a/bom/GabozePocaioRound2.csv
+++ b/bom/GabozePocaioRound2.csv
@@ -6,7 +6,7 @@ R4,RES 150 OHM 1% 1/4W 0805,RNCP0805FTD150R,https://www.digikey.ca/product-detai
 "R5, R10",Replacement Volume Switch for Game boy,N/A,https://www.aliexpress.com/item/Replacement-Volume-Switch-for-Game-boy-for-GBA-GBC-Motherboard-Potentiomete-100pcs-lot/32830491244.html,2
 C1,CAP TANT 100UF 4V 20% 1206,F930G107MAA,https://www.digikey.ca/product-detail/en/avx-corporation/F930G107MAA/478-8134-1-ND/4005954,1
 "C3,C4",CAP CER 1UF 25V X7R 0805,C0805C105K3RACTU,https://www.digikey.ca/product-detail/en/kemet/C0805C105K3RACTU/399-8004-1-ND/3471727,2
-C2,CAP CER 220PF 50V X7R 0805,C0805C221M5RACTU,https://www.digikey.ca/product-detail/en/kemet/C0805C221M5RACTU/399-8039-1-ND/3471762,1
+C2,CAP CER 0.22UF 50V X7R 0805,C0805C224K5RACTU,https://www.digikey.ca/product-detail/en/kemet/C0805C224K5RACTU/399-3491-1-ND/754784
 J1,CONN JACK STEREO 3.5MM R/A,CP1-3525NG-PI-ND,https://www.digikey.ca/product-detail/en/cui-inc/SJ1-3525NG-PI/CP1-3525NG-PI-ND/2295991,1
 J2,SPEAKER 8OHM 250MW TOP PORT 80DB,PSR-20F08S-JQ,https://www.digikey.ca/product-detail/en/mallory-sonalert-products-inc/PSR-20F08S-JQ/458-1122-ND/2071438,1
 J3,CONN HEADER PH SIDE 2POS 2MM SMD,S2B-PH-SM4-TB(LF)(SN,https://www.digikey.ca/product-detail/en/jst-sales-america-inc/S2B-PH-SM4-TB(LF)(SN)/455-1749-1-ND/926846,1

--- a/eagle/GabozePocaioRound2.brd
+++ b/eagle/GabozePocaioRound2.brd
@@ -191,7 +191,7 @@ C4</text>
 <text x="2" y="18" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0" align="top-right">100K
 150
 100uF
-220pF
+220nF
 1uF
 1uF</text>
 <wire x1="1" y1="19" x2="1" y2="10.5" width="0.1524" layer="22"/>
@@ -37761,7 +37761,7 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="11" y="110.73" size="0.8128" layer="28" font="vector" ratio="15" rot="MR180" align="center"/>
 </element>
 <element name="U1" library="texas" library_urn="urn:adsk.eagle:library:387" package="SOIC8" value="LM4875" x="12" y="6.5" smashed="yes" rot="MR90"/>
-<element name="C2" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="C0805" value="220pF" x="5" y="8" smashed="yes" rot="MR0"/>
+<element name="C2" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="C0805" value="220nF" x="5" y="8" smashed="yes" rot="MR0"/>
 <element name="C3" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="C0805" value="1uF" x="22" y="5" smashed="yes" rot="MR180"/>
 <element name="C4" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="C0805" value="1uF" x="5" y="5" smashed="yes" rot="MR0"/>
 <element name="J2" library="SparkFun-Connectors" library_urn="urn:adsk.eagle:library:513" package="1X02" package3d_urn="urn:adsk.eagle:package:38039/1" value="SPKR" x="48.25" y="7.5" smashed="yes" rot="MR270">

--- a/eagle/GabozePocaioRound2.sch
+++ b/eagle/GabozePocaioRound2.sch
@@ -11428,7 +11428,7 @@ FACING AWAY FROM BOARD</text>
 <part name="GND27" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="GND" device=""/>
 <part name="U$1" library="SparkFun-Retired" library_urn="urn:adsk.eagle:library:533" deviceset="SWITCH_SPDT" device=""/>
 <part name="U1" library="texas" library_urn="urn:adsk.eagle:library:387" deviceset="LM4875" device=""/>
-<part name="C2" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="C-US" device="C0805" value="220pF"/>
+<part name="C2" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="C-US" device="C0805" value="220nF"/>
 <part name="GND29" library="SparkFun-Aesthetics" library_urn="urn:adsk.eagle:library:507" deviceset="GND" device=""/>
 <part name="C3" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="C-US" device="C0805" value="1uF"/>
 <part name="GND35" library="SparkFun-Aesthetics" library_urn="urn:adsk.eagle:library:507" deviceset="GND" device=""/>


### PR DESCRIPTION
In the datasheet of LM4875 [1], Texas Instruments recommends a 0.22uF (which is 220nF [2]) AC-coupling capacitor at the audio input port [3]. However, in the Eagle and BOM files of Gaboze Pocaio Round 2, the capacitor value was specified as 220pF by accident. Experiments showed that using a 220pF capacitor instead of 220nF causes an audible distortion of the headphone output, which is characterized by the lack of bass due to the RC high-pass filter action.

This commit corrects the component value C2 from 220pF to 220nF in Eagle schematic and board design files. Also, in the BOM,

    C2,CAP CER 220PF 50V X7R 0805,C0805C221M5RACTU

has been replaced by

    C2,CAP CER 0.22UF 50V X7R 0805,C0805C224K5RACTU

Applying this fix to the circuit board fixes the audible distortion and allows the audio quality to be restored to TI's reference design.

It should be note that the Gerber files are not corrected, since the committer doesn't have the project settings required to create an identical set of Gerber files. The Gerber files should be updated in a later commit by the original author.

[1] https://www.ti.com/lit/ds/symlink/lm4875.pdf

[2] https://en.wikipedia.org/wiki/Metric_prefix

[3] See Figure 1.

> Signed-off-by: Tom Li <tomli@tomli.me>